### PR TITLE
Feature/issue 6

### DIFF
--- a/services/17kmmrbot/src/commands/notablePlayers.ts
+++ b/services/17kmmrbot/src/commands/notablePlayers.ts
@@ -73,9 +73,13 @@ export class NotablePlayersCommand implements TwitchCommand {
 				);
 			}
 
-			const averageMMR = await this.extractorService.getAverageMMR(
+			// Get current user to calculate average based on the user (or spectator)
+			const lobbyUser = fps.lobby.players[user.steamid];
+
+			const averageMMR = this.extractorService.getAverageMMR(
 				fps,
 				leaderboard,
+				lobbyUser,
 			);
 
 			let response = `${gameMode} [${averageMMR} avg MMR]: `;

--- a/services/17kmmrbot/src/services/extractor.ts
+++ b/services/17kmmrbot/src/services/extractor.ts
@@ -112,16 +112,8 @@ export class ExtractorService {
 
 				let interpolatedMMR = 0;
 
-				// If we find a lord without a leaderboard rank, assume 15k mmr
+				// If we find a lord without a leaderboard rank, do not add them to the average
 				// For all players below lord, interpolate the mmr
-				if (
-					majorRank === 8 &&
-					(global_leaderboard_rank === null ||
-						global_leaderboard_rank === undefined)
-				) {
-					interpolatedMMR = 15000;
-				}
-
 				if (majorRank === 7) {
 					interpolatedMMR = adjustedBigBossRanks[minorRank];
 				}

--- a/services/17kmmrbot/src/services/extractor.ts
+++ b/services/17kmmrbot/src/services/extractor.ts
@@ -110,12 +110,12 @@ export class ExtractorService {
 			leaderboardEntries?.map((entry) => entry.level_score) ?? [];
 
 		// Check if there are any lords in the lobby in case the user is a spectator
-		const lordLobby: boolean =
-			players
-				.map((player) => player.rank_tier)
-				.filter((rank_tier) => rank_tier === 80).length > 0
-				? true
-				: false;
+		const lordLobby: boolean = players
+			.map((player) => player.rank_tier)
+			.reduce<boolean>(
+				(acc, rank_tier) => acc || rank_tier === 80,
+				false,
+			);
 
 		for (const { rank_tier, global_leaderboard_rank } of players) {
 			if (rank_tier) {


### PR DESCRIPTION
Fixes inactive lords not being taken into account for average lord MMR calculations. Also calculates average differently based on the current user (normal averages for people below lord and lord averages for users who are lord). If the user is a spectator, the decision is made based on whether lords exist in the lobby. This should close #6 