### PR TITLE
Removed instant message resolving in FSM and Historization

### DIFF
--- a/services/fsm/package.json
+++ b/services/fsm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fsm",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Finite State Machine",
   "author": {
     "name": "Thomas Kosiewski"

--- a/services/fsm/src/index.ts
+++ b/services/fsm/src/index.ts
@@ -60,93 +60,85 @@ const {
 
 	consumer.run({
 		autoCommit: KAFKA_AUTO_COMMIT !== "false" ?? true,
-		eachMessage: async ({ message, topic }) =>
-			new Promise<void>(async (resolve) => {
-				resolve();
+		eachMessage: async ({ message, topic }) => {
+			const value = message.value.toString();
 
-				const value = message.value.toString();
+			if (topic === FortifyEventTopics.SYSTEM) {
+				const event: FortifyEvent<SystemEventType> = JSON.parse(value);
+				const steamid = event["steamid"] as string | null;
 
-				if (topic === FortifyEventTopics.SYSTEM) {
-					const event: FortifyEvent<SystemEventType> = JSON.parse(
-						value,
-					);
-					const steamid = event["steamid"] as string | null;
+				if (steamid) {
+					let state = await stateTransformer.loadState(steamid);
 
-					if (steamid) {
-						let state = await stateTransformer.loadState(steamid);
-
-						for (const commandReducer of commandReducers) {
-							state = await commandReducer.processor(
-								state,
-								event,
-							);
-						}
-
-						await stateTransformer.saveState(state, steamid);
+					for (const commandReducer of commandReducers) {
+						state = await commandReducer.processor(state, event);
 					}
+
+					await stateTransformer.saveState(state, steamid);
 				}
+			}
 
-				if (topic === "gsi") {
-					try {
-						const gsi: Log = JSON.parse(value);
-						const jwt = verify(gsi.auth, JWT_SECRET ?? "");
+			if (topic === "gsi") {
+				try {
+					const gsi: Log = JSON.parse(value);
+					const jwt = verify(gsi.auth, JWT_SECRET ?? "");
 
-						if (jwt instanceof Object) {
-							const context = jwt as Context;
+					if (jwt instanceof Object) {
+						const context = jwt as Context;
 
-							let state = await stateTransformer.loadState(
-								context.user.id,
-							);
+						let state = await stateTransformer.loadState(
+							context.user.id,
+						);
 
-							for (const { data } of gsi.block) {
-								for (const {
-									public_player_state,
-									private_player_state,
-								} of data) {
-									if (public_player_state) {
-										for (const reducer of publicStateReducers) {
-											try {
-												state = await reducer.processor(
-													state,
-													context,
-													public_player_state,
-												);
-											} catch (e) {
-												debug(
-													"app::consumer::public_player_state",
-												)(e);
-											}
+						for (const { data } of gsi.block) {
+							for (const {
+								public_player_state,
+								private_player_state,
+							} of data) {
+								if (public_player_state) {
+									for (const reducer of publicStateReducers) {
+										try {
+											state = await reducer.processor(
+												state,
+												context,
+												public_player_state,
+											);
+										} catch (e) {
+											debug(
+												"app::consumer::public_player_state",
+											)(e);
 										}
 									}
+								}
 
-									if (private_player_state) {
-										for (const reducer of privateStateReducers) {
-											try {
-												state = await reducer.processor(
-													state,
-													context,
-													private_player_state,
-												);
-											} catch (e) {
-												debug(
-													"app::consumer::private_player_state",
-												)(e);
-											}
+								if (private_player_state) {
+									for (const reducer of privateStateReducers) {
+										try {
+											state = await reducer.processor(
+												state,
+												context,
+												private_player_state,
+											);
+										} catch (e) {
+											debug(
+												"app::consumer::private_player_state",
+											)(e);
 										}
 									}
 								}
 							}
-
-							await stateTransformer.saveState(
-								state,
-								context.user.id,
-							);
 						}
-					} catch (e) {
-						debug("app::consumer::eachMessage")(e);
+
+						await stateTransformer.saveState(
+							state,
+							context.user.id,
+						);
 					}
+				} catch (e) {
+					debug("app::consumer::eachMessage")(e);
 				}
-			}).catch(debug("app::eachMessage")),
+			}
+		},
 	});
 
 	if (KAFKA_START_OFFSET) {

--- a/services/historization/package.json
+++ b/services/historization/package.json
@@ -1,6 +1,6 @@
 {
   "name": "historization",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "description": "A historization service responsible for persisting info",
   "author": {
     "name": "Thomas Kosiewski"


### PR DESCRIPTION
In case some of the background databases fail, the Kafka messages would not be acknowledged, thus information would not get lost.